### PR TITLE
chore: Restrict Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
       "vue-cli-service lint",
       "git add"
     ]
+  },
+  "engines": {
+    "node": ">=12.0.0 <18.0.0"
   }
 }


### PR DESCRIPTION
This library only works with Node.js <18.0.0